### PR TITLE
add check for CPU type and warning if running on an M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Be sure to update the remote url: `git remote set-url origin https://github.com/
 
 
 ### **MacOS with an M1 processor is *NOT* recommended for this repo**
-The way Docker for Mac on an Arm chip is designed makes the I/O incredibly slow, and blockchains are ***very*** heavy on I/O. \
-This only seems to affect MacOS, other Arm based systems seem to work fine. 
+⚠️ The way Docker for Mac on an Arm chip is designed makes the I/O incredibly slow, and blockchains are ***very*** heavy on I/O. \
+This only seems to affect MacOS, other Arm based systems seem to work fine.
 
 
 
@@ -17,20 +17,20 @@ This only seems to affect MacOS, other Arm based systems seem to work fine.
 
 
 ### **Install/Update docker-compose**
-*Note: `docker-compose` executable is required, even though recent versions of Docker contain `compose` natively*  
-[Install Docker-compose](https://docs.docker.com/compose/install/)  
-[Docker Desktop for Mac](https://docs.docker.com/docker-for-mac/install/)  
-[Docker Desktop for Windows](https://docs.docker.com/docker-for-windows/install/)  
-[Docker Engine for Linux](https://docs.docker.com/engine/install/#server)  
-  
-  
-First, check if you have `docker-compose` installed locally. 
+*Note: `docker-compose` executable is required, even though recent versions of Docker contain `compose` natively*
+[Install Docker-compose](https://docs.docker.com/compose/install/)
+[Docker Desktop for Mac](https://docs.docker.com/docker-for-mac/install/)
+[Docker Desktop for Windows](https://docs.docker.com/docker-for-windows/install/)
+[Docker Engine for Linux](https://docs.docker.com/engine/install/#server)
 
-To do that, run this command in your terminal : 
+
+First, check if you have `docker-compose` installed locally.
+
+To do that, run this command in your terminal :
 ```bash
 docker-compose --version
-``` 
-Output should look something very similar to this : 
+```
+Output should look something very similar to this :
 ```
 docker-compose version 1.27.4, build 40524192
 ```
@@ -119,7 +119,7 @@ cp sample.env .env
 ```
 
 ## **Accessing the services**
-*Note*: For networks other than `mocknet`, downloading the initial headers can take several minutes. Until the headers are downloaded, the `/v2/info` endpoints won't return any data. 
+*Note*: For networks other than `mocknet`, downloading the initial headers can take several minutes. Until the headers are downloaded, the `/v2/info` endpoints won't return any data.
 Use the command `./manage.sh <network> logs` to check the sync progress
 
 **stacks-blockchain**:
@@ -238,14 +238,14 @@ _**Containers not starting (hanging on start)**_:
 - Occasionally, docker can get **stuck** and not allow new containers to start. If this happens, simply restart your docker daemon and try again.
 
 _**BNS Data not imported/incorrect**_:
-- This could happen if a file exists, but is empty or truncated. The script to extract these files *should* address this, but if it doesn't you can manually extract the files. 
+- This could happen if a file exists, but is empty or truncated. The script to extract these files *should* address this, but if it doesn't you can manually extract the files.
 ```bash
 wget https://storage.googleapis.com/blockstack-v1-migration-data/export-data.tar.gz -O ./persistent-data/bns-data/export-data.tar.gz
 tar -xvzf ./persistent-data/bns-data/export-data.tar.gz -C ./persistent-data/bns-data/
 ```
 
 _**Database Issues**_:
-- For any of the various Postgres/sync issues, it may be easier to simply remove the persistent data dir. Note that doing so will result in a longer startup time as the data is repopulated. 
+- For any of the various Postgres/sync issues, it may be easier to simply remove the persistent data dir. Note that doing so will result in a longer startup time as the data is repopulated.
 ```bash
 ./manage.sh <network> reset
 ./manage.sh <network> restart
@@ -264,7 +264,7 @@ _**API Missing Parent Block Error**_:\
 ./manage.sh <network> restart
 ```
 
-- To wipe data and re-sync from genesis 
+- To wipe data and re-sync from genesis
 ```bash
 ./manage.sh <network> reset
 ./manage.sh <network> restart

--- a/manage.sh
+++ b/manage.sh
@@ -31,7 +31,7 @@ check_device() {
         echo "⚠️  WARNING"
         echo "⚠️  MacOS M1 CPU detected - NOT recommended for this repo"
         echo "⚠️  see README for details"
-        echo "⚠️  https://github.com/dcsan/stacks-blockchain-docker#macos-with-an-m1-processor-is-not-recommended-for-this-repo "
+        echo "⚠️  https://github.com/stacks-network/stacks-blockchain-docker#macos-with-an-m1-processor-is-not-recommended-for-this-repo"
         read -p "Press enter to continue anyway or Ctrl+C to exit"
     fi
 }

--- a/manage.sh
+++ b/manage.sh
@@ -24,7 +24,17 @@ usage() {
 	echo "      ex: $0 mainnet up"
 	echo
 	exit 0
-} 
+}
+
+check_device() {
+    if [[ `uname -m` == 'arm64' ]]; then
+        echo "⚠️  WARNING"
+        echo "⚠️  MacOS M1 CPU detected - NOT recommended for this repo"
+        echo "⚠️  see README for details"
+        echo "⚠️  https://github.com/dcsan/stacks-blockchain-docker#macos-with-an-m1-processor-is-not-recommended-for-this-repo "
+        read -p "Press enter to continue anyway or Ctrl+C to exit"
+    fi
+}
 
 check_network() {
 	if [[ $(docker-compose -f configurations/common.yaml ps -q) ]]; then
@@ -57,7 +67,7 @@ reset_data() {
 			echo "  Run: $0 ${NETWORK} down"
 			echo "  And try again"
 			echo
-			exit 
+			exit
 		fi
 	fi
 	exit 0
@@ -72,7 +82,7 @@ ordered_stop() {
 docker_logs(){
 	PARAM="-f"
 	if ! check_network; then
-		echo 
+		echo
 		echo "*** No ${NETWORK} services running ***"
 		usage
 	fi
@@ -84,7 +94,7 @@ docker_down () {
 	if ! check_network; then
 		echo
 		echo "*** stacks-blockchain network is not running ***"
-		echo 
+		echo
 		return
 	fi
 	if [[ ${NETWORK} == "mainnet" || ${NETWORK} == "testnet" ]];then
@@ -137,7 +147,11 @@ case ${NETWORK} in
     	;;
 esac
 
-case ${ACTION} in 
+
+check_device
+
+case ${ACTION} in
+
 	up|start)
 		docker_up
 		;;


### PR DESCRIPTION
closes #53

Use the following template to create your pull request

## Description
add a warning if run on an M1 mac to prevent people wasting days when we know it doesn't work
see #53 for thread example.
only the startup script has a detect_device added

![image](https://user-images.githubusercontent.com/514002/150581274-fea39c0e-0d57-4444-8ef3-c294410d4333.png)

no code changes to main codecase just the shellscript warning and an ⚠️  in the README 


## Checklist
- [NA] Code is commented where needed
- [NA] Unit test coverage for new or modified code paths
- [NA] `npm run test` passes. (cannot run anything on an M1)
- [NA] Changelog is updated
- [x] Tag 1 of @person1 or @person2.   @wileyj  ?

