### PR TITLE
Adding a proxy container

### DIFF
--- a/configurations/nginx/default.conf
+++ b/configurations/nginx/default.conf
@@ -1,0 +1,16 @@
+upstream stacks-blockchain-api {
+  server  stacks-blockchain-api:3999;
+}
+server {
+  listen       80;
+  server_name  localhost;
+  location /status {
+    default_type text/plain;
+    return 200 ok;
+  }
+  location / {
+    add_header Access-Control-Allow-Origin *;
+    proxy_pass http://stacks-blockchain-api/;
+    break;
+  }
+}

--- a/configurations/proxy.yaml
+++ b/configurations/proxy.yaml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  nginx:
+    image: nginx:alpine
+    container_name: nginx
+    restart: on-failure
+    ports:
+      - ${NGINX_PROXY_PORT:-80}:80
+    networks:
+      - stacks-blockchain
+    profiles:
+      - stacks-blockchain
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf

--- a/sample.env
+++ b/sample.env
@@ -18,7 +18,11 @@ STACKS_BLOCKCHAIN_API_DB=pg
 STACKS_CORE_RPC_HOST=stacks-blockchain
 STACKS_CORE_RPC_PORT=20443
 STACKS_EXPORT_EVENTS_FILE=/tmp/event-replay/stacks-node-events.tsv
-#BNS_IMPORT_DIR=/bns-data
+# STACKS_API_ENABLE_FT_METADATA=1
+# STACKS_API_ENABLE_NFT_METADATA=1
+# STACKS_API_TOKEN_METADATA_ERROR_MODE=warning
+# STACKS_ADDRESS_CACHE_SIZE=10000
+# BNS_IMPORT_DIR=/bns-data
 
 ###############################
 ## Postgres
@@ -31,9 +35,9 @@ POSTGRES_PASSWORD=postgres
 ## Docker image versions
 ## 
 STACKS_BLOCKCHAIN_VERSION=2.05.0.1.0
-STACKS_BLOCKCHAIN_API_VERSION=2.0.0
+STACKS_BLOCKCHAIN_API_VERSION=2.1.1
 
 # version of the postgres image to use (if there is existing data, set to this to version 13)
 POSTGRES_VERSION=13
 
-
+NGINX_PROXY_PORT=80


### PR DESCRIPTION
Adding nginx as a proxy container running on port 80, proxying to the API container.


adjuste the controller manage.sh script by adding an extra flag to the args that can be used like: `./manage.sh mainnet start proxy` which will launch an nginx proxy:
```
$ curl -sL localhost/v2/info | jq
{
  "peer_version": 402653189,
  "pox_consensus": "dd95433864e152b5368b0ed8ec184ec376b62c67",
  "burn_block_height": 667545,
  "stable_pox_consensus": "60a10bc9f28f1f32f08d61296bfa18f2079850fa",
  "stable_burn_block_height": 667538,
  "server_version": "stacks-node 2.05.0.1.0 (master:de541f9, release build, linux [x86_64])",
  "network_id": 1,
  "parent_network_id": 3652501241,
  "stacks_tip_height": 1136,
  "stacks_tip": "aadf3d2c6d0a434bea6941d716b69f912182cd6634b527219f4279388ee7523f",
  "stacks_tip_consensus_hash": "f375404ca323d8090f796efeb39db03016121c62",
  "genesis_chainstate_hash": "74237aa39aa50a83de11a4f53e9d3bb7d43461d1de9873f402e5453ae60bc59b",
  "unanchored_tip": "62ad94bbb647e795de4e85f19da77277bb6451093a22a4c4b104b3c0092c597a",
  "unanchored_seq": 0,
  "exit_at_block_height": null
}
$ curl -sL localhost | jq
{
  "server_version": "stacks-blockchain-api v2.1.1 (master:d7624e13)",
  "status": "ready"
}
```