### PR TITLE
API Version bump to 7.8.2

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -54,7 +54,7 @@ NGINX_PROXY_PORT=80
 ## Docker image versions
 ## 
 STACKS_BLOCKCHAIN_VERSION=2.4.0.0.4
-STACKS_BLOCKCHAIN_API_VERSION=7.3.2
+STACKS_BLOCKCHAIN_API_VERSION=7.8.2
 # version of the postgres image to use (if there is existing data, set to this to version 13)
 # if starting a new sync from genesis, can use any version > 13
 POSTGRES_VERSION=15


### PR DESCRIPTION
Tested with version 7.8.2 and works as expected

Use the following template to create your pull request

## Description

Bumping up the API version to v7.8.2 to take advantage of the recent changes. Also https://api.hiro.so node is now updated to v7.8.2 and is what is currently live.

## Type of Change
Change to `Sample.env` file

## Does this introduce a breaking change?
No breaking change

## Are documentation updates required?
No updates to docs required

## Testing information

Started Node + API and is syncing as expected.

## Checklist
- [] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @person1 or @person2
