### PR TITLE
Fix: stacks_blockchain_api_version in sample.env

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -54,7 +54,7 @@ NGINX_PROXY_PORT=80
 ## Docker image versions
 ## 
 STACKS_BLOCKCHAIN_VERSION=2.5.0.0.3
-STACKS_BLOCKCHAIN_API_VERSION=7.10.1
+STACKS_BLOCKCHAIN_API_VERSION=7.11.0
 # version of the postgres image to use (if there is existing data, set to this to version 13)
 # if starting a new sync from genesis, can use any version > 13
 POSTGRES_VERSION=15


### PR DESCRIPTION
## Description

Version 7.10.1 does not exists yet. So 7.11.0 has to be used for now.

Fixes #118 

## Type of Change
- Bug fix

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

Perform tasks according to README
