### PR TITLE
feat: add support to 3.0.0.0.0

### DIFF
--- a/conf/mainnet/Config.toml.sample
+++ b/conf/mainnet/Config.toml.sample
@@ -6,7 +6,6 @@ bootstrap_node = "02196f005965cebe6ddc3901b7b1cc1aa7a88f305bb8c5893456b8f9a60592
 
 [[events_observer]]
 endpoint = "stacks-blockchain-api:3700"
-retry_count = 255
 events_keys = ["*"]
 
 [burnchain]

--- a/conf/mocknet/Config.toml.sample
+++ b/conf/mocknet/Config.toml.sample
@@ -6,7 +6,6 @@ use_test_genesis_chainstate = true
 
 [[events_observer]]
 endpoint = "stacks-blockchain-api:3700"
-retry_count = 255
 events_keys = ["*"]
 
 [burnchain]

--- a/conf/testnet/Config.toml.sample
+++ b/conf/testnet/Config.toml.sample
@@ -16,7 +16,6 @@ peer_port = 18333
 
 [[events_observer]]
 endpoint = "stacks-blockchain-api:3700"
-retry_count = 255
 events_keys = ["*"]
 
 [[ustx_balance]]

--- a/sample.env
+++ b/sample.env
@@ -47,14 +47,14 @@ STACKS_SHUTDOWN_TIMEOUT=1200
 
 ###############################
 ## Nginx proxy
-## 
+##
 NGINX_PROXY_PORT=80
 
 ###############################
 ## Docker image versions
-## 
-STACKS_BLOCKCHAIN_VERSION=2.5.0.0.3
-STACKS_BLOCKCHAIN_API_VERSION=7.11.0
+##
+STACKS_BLOCKCHAIN_VERSION=3.0.0.0.0
+STACKS_BLOCKCHAIN_API_VERSION=8.1.2
 # version of the postgres image to use (if there is existing data, set to this to version 13)
 # if starting a new sync from genesis, can use any version > 13
 POSTGRES_VERSION=15


### PR DESCRIPTION
## Description

Update this repo to run the latest node version for the upcoming hardfork. This pr does the following change:
1. Update the versions of the node and API for docker
2. Fix a config issue that started to appear when upgrading to the latest node version to fix that error:
> stacks-blockchain      | WARN [1729874212.241844] [testnet/stacks-node/src/main.rs:347] [main] Invalid config file: Invalid toml: unknown field `retry_count`, expected one of `endpoint`, `events_keys`, `timeout_ms` for key `events_observer` at line 12 column 1

## Type of Change
<!-- Explain or annotate the nature of your changes, see examples below -->
- New feature

## Does this introduce a breaking change?
A mandatory breaking change that will comes with the hardfork

## Are documentation updates required?
No

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @wileyj 
