### PR TITLE
Add signer and update versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,11 @@ Session.vim
 node_modules/
 stacks-node-follower/Config.toml
 configurations/*/Config.toml
+configurations/*/Signer.toml
 configurations/private-testnet/*.toml
 
 conf/*/Config.toml
+conf/*/Signer.toml
 conf/*/Config-with-bitcoin-flag.toml
 conf/*/bitcoin.conf
 conf/private-testnet/*.toml

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cp sample.env .env
 ### Seed chainstate from Hiro Archiver
 
 Using data from the [Hiro Archiver](https://docs.hiro.so/hiro-archive) service, this script will download the latest files, extract them and restore the postgres data. \
-_**Note**: it can take a long time to process the data, and you'll need at a minimum roughly 150GB of free space_
+_**Note**: it can take a long time to process the data, and you'll need at a minimum roughly 350GB of free space_
 
 ```bash
 sudo ./scripts/seed-chainstate.sh

--- a/conf/mainnet/Config.toml.sample
+++ b/conf/mainnet/Config.toml.sample
@@ -3,11 +3,7 @@ working_dir = "/root/stacks-blockchain/data"
 rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
 bootstrap_node = "02196f005965cebe6ddc3901b7b1cc1aa7a88f305bb8c5893456b8f9a605923893@seed.mainnet.hiro.so:20444"
-
-[[events_observer]]
-endpoint = "stacks-blockchain-api:3700"
-retry_count = 255
-events_keys = ["*"]
+stacker = true
 
 [burnchain]
 chain = "bitcoin"
@@ -17,3 +13,16 @@ username = "stacks"
 password = "foundation"
 rpc_port = 8332
 peer_port = 8333
+
+[connection_options]
+auth_token = "1234"
+private_neighbors = false
+
+[[events_observer]]
+events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
+endpoint = "stacks-signer:30000"
+
+[[events_observer]]
+endpoint = "stacks-blockchain-api:3700"
+events_keys = ["*"]
+timeout_ms = 300_000

--- a/conf/mocknet/Config.toml.sample
+++ b/conf/mocknet/Config.toml.sample
@@ -3,16 +3,21 @@ rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
 wait_time_for_microblocks = 10000
 use_test_genesis_chainstate = true
-
-[[events_observer]]
-endpoint = "stacks-blockchain-api:3700"
-retry_count = 255
-events_keys = ["*"]
+stacker = true
 
 [burnchain]
 chain = "bitcoin"
 mode = "mocknet"
 commit_anchor_block_within = 5000
+
+[[events_observer]]
+events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
+endpoint = "stacks-signer:30000"
+
+[[events_observer]]
+endpoint = "stacks-blockchain-api:3700"
+events_keys = ["*"]
+timeout_ms = 60_000
 
 [[ustx_balance]]
 # "mnemonic": "point approve language letter cargo rough similar wrap focus edge polar task olympic tobacco cinnamon drop lawn boring sort trade senior screen tiger climb",
@@ -59,6 +64,8 @@ address = "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7"
 amount = 100000000000000
 
 [connection_options]
+auth_token = "1234"
+private_neighbors = false
 read_only_call_limit_write_length = 0
 read_only_call_limit_read_length = 100000
 read_only_call_limit_write_count = 0

--- a/conf/testnet/Config.toml.sample
+++ b/conf/testnet/Config.toml.sample
@@ -2,22 +2,31 @@
 working_dir = "/root/stacks-blockchain/data"
 rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
-bootstrap_node="029266faff4c8e0ca4f934f34996a96af481df94a89b0c9bd515f3536a95682ddc@seed.testnet.hiro.so:30444"
-always_use_affirmation_maps = false
+bootstrap_node = "029266faff4c8e0ca4f934f34996a96af481df94a89b0c9bd515f3536a95682ddc@seed.testnet.hiro.so:30444"
+always_use_affirmation_maps = true
+require_affirmed_anchor_blocks = true
+pox_sync_sample_secs = 30
+stacker = true
 
 [burnchain]
-chain = "bitcoin"
-mode = "xenon"
-peer_host = "bitcoin.testnet.stacks.org"
-username = "stacks"
-password = "foundation"
-rpc_port = 18332
-peer_port = 18333
+mode = "krypton"
+peer_host = "bitcoin.regtest.hiro.so"
+peer_port = 18444
+pox_prepare_length = 100
+pox_reward_length = 900
+
+[connection_options]
+auth_token = "1234"
+private_neighbors = false
+
+[[events_observer]]
+events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
+endpoint = "stacks-signer:30000"
 
 [[events_observer]]
 endpoint = "stacks-blockchain-api:3700"
-retry_count = 255
 events_keys = ["*"]
+timeout_ms = 60_000
 
 [[ustx_balance]]
 address = "ST2QKZ4FKHAH1NQKYKYAYZPY440FEPK7GZ1R5HBP2"
@@ -34,3 +43,39 @@ amount = 10000000000000000
 [[ustx_balance]]
 address = "ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B"
 amount = 10000000000000000
+
+[[burnchain.epochs]]
+epoch_name = "1.0"
+start_height = 0
+
+[[burnchain.epochs]]
+epoch_name = "2.0"
+start_height = 0
+
+[[burnchain.epochs]]
+epoch_name = "2.05"
+start_height = 1
+
+[[burnchain.epochs]]
+epoch_name = "2.1"
+start_height = 2
+
+[[burnchain.epochs]]
+epoch_name = "2.2"
+start_height = 3
+
+[[burnchain.epochs]]
+epoch_name = "2.3"
+start_height = 4
+
+[[burnchain.epochs]]
+epoch_name = "2.4"
+start_height = 5
+
+[[burnchain.epochs]]
+epoch_name = "2.5"
+start_height = 6
+
+[[burnchain.epochs]]
+epoch_name = "3.0"
+start_height = 56_457

--- a/docs/config.md
+++ b/docs/config.md
@@ -5,7 +5,9 @@ _Note: Burnchchain environment variables defined in `./env` will overwrite value
 
 - `.env`
 - `./conf/mainnet/Config.toml`
+- `./conf/mainnet/Signer.toml`
 - `./conf/testnet/Config.toml`
+- `./conf/testnet/Signer.toml`
 
 ## Environment Variables
 
@@ -19,9 +21,21 @@ Most variables in `.env` shouldn't be modified, but there are a few you may wish
 | `DOCKER_NETWORK`                | Name of docker network used to launch services        | `stacks`                  |
 | `EXPOSE_POSTGRES`               | Expose postgres service to the host OS                | `false`                   |
 | `STACKS_BLOCKCHAIN_VERSION`     | Stacks Blockchain Docker image version                | `latest released version` |
+| `STACKS_SIGNER_VERSION`         | Stacks Signer Docker image version                    | `latest released version` |
 | `STACKS_BLOCKCHAIN_API_VERSION` | Stacks Blockchain API Docker image version            | `latest released version` |
 | `POSTGRES_VERSION`              | Postgres Docker image version                         | `14`                      |
 | `NGINX_PROXY_PORT`              | HTTP port for the nginx proxy                         | `80`                      |
+
+### Stacks Signer Settings
+
+#### You must set values for the _SIGNER_PRIVATE_KEY_ on the specific network if you're running a signer, otherwise they can be left empty.
+
+| Name                         | Description                                                                                      | Default Value |
+| ---------------------------- | ------------------------------------------------------------------------------------------------ | ------------- |
+| `AUTH_TOKEN`                 | Authorization token for HTTP requests made from the signer to your Stacks node                   | `1234`        |
+| `SIGNER_PRIVATE_KEY`         | The private key of the signer, on mainnet.                                                       |               |
+| `TESTNET_SIGNER_PRIVATE_KEY` | The private key of the signer, on testnet.                                                       |               |
+| `STACKS_SIGNER_PORT`         | The port where the signer will expose an RPC endpoint for receiving events from your Stacks node | `30000`       |
 
 ### API Settings
 
@@ -81,8 +95,6 @@ Most variables in `.env` shouldn't be modified, but there are a few you may wish
 
 | Name            | Description                           | Default Value                |
 | --------------- | ------------------------------------- | ---------------------------- |
-| `TBTC_HOST`     | FQDN of bitcoin mainnnet host         | `bitcoin.testnet.stacks.org` |
-| `TBTC_RPC_USER` | RPC username for bitcoin mainnet host | `stacks`                     |
-| `TBTC_RPC_PASS` | RPC password for bitcoin mainnet host | `foundation`                 |
-| `TBTC_RPC_PORT` | RPC port for bitcoin mainnet host     | `18332`                      |
-| `TBTC_P2P_PORT` | P2P port for bitcoin mainnet host     | `18333`                      |
+| `TBTC_HOST`     | FQDN of bitcoin testnet host         | `bitcoin.regtest.hiro.so` |
+| `TBTC_RPC_PORT` | RPC port for bitcoin testnet host     | `18332`                      |
+| `TBTC_P2P_PORT` | P2P port for bitcoin testnet host     | `18333`                      |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,9 +8,10 @@ Usage:
         -n|--network: [ mainnet | testnet | mocknet ]
         -a|--action: [ start | stop | logs | reset | upgrade | import | export | bns ]
     optional args:
-        -f|--flags: [ proxy ]
+        -f|--flags: [ signer,proxy ]
         export: combined with 'logs' action, exports logs to a text file
     ex: ./manage.sh -n mainnet -a start -f proxy
+	ex: ./manage.sh -n mainnet -a start -f signer,proxy
     ex: ./manage.sh --network mainnet --action start --flags proxy
     ex: ./manage.sh -n mainnet -a logs export
 ```
@@ -23,6 +24,16 @@ Usage:
 
 ```bash
 ./manage.sh -n <network> -a restart
+```
+
+#### With optional signer
+
+```bash
+./manage.sh -n <network> -a start -f signer
+```
+
+```bash
+./manage.sh -n <network> -a restart -f signer
 ```
 
 #### With optional proxy

--- a/sample.env
+++ b/sample.env
@@ -4,6 +4,14 @@ EXPOSE_POSTGRES=false
 NETWORK=mainnet
 
 ###############################
+## Stacks Signer
+##
+AUTH_TOKEN=1234
+SIGNER_PRIVATE_KEY=
+TESTNET_SIGNER_PRIVATE_KEY=
+STACKS_SIGNER_PORT=30000
+
+###############################
 ## Stacks Blockchain API
 ##
 NODE_ENV=production
@@ -53,8 +61,9 @@ NGINX_PROXY_PORT=80
 ###############################
 ## Docker image versions
 ## 
-STACKS_BLOCKCHAIN_VERSION=2.5.0.0.3
-STACKS_BLOCKCHAIN_API_VERSION=7.11.0
+STACKS_BLOCKCHAIN_VERSION=3.0.0.0.0
+STACKS_SIGNER_VERSION=3.0.0.0.0.0
+STACKS_BLOCKCHAIN_API_VERSION=8.1.0
 # version of the postgres image to use (if there is existing data, set to this to version 13)
 # if starting a new sync from genesis, can use any version > 13
 POSTGRES_VERSION=15
@@ -67,8 +76,6 @@ BTC_RPC_PORT=8332
 BTC_P2P_PORT=8333
 
 ## Testnet Defaults
-TBTC_HOST=bitcoin.testnet.stacks.org
-TBTC_RPC_USER=stacks
-TBTC_RPC_PASS=foundation
-TBTC_RPC_PORT=18332
-TBTC_P2P_PORT=18333
+TBTC_HOST=bitcoin.regtest.hiro.so
+TBTC_RPC_PORT=18443
+TBTC_P2P_PORT=18444


### PR DESCRIPTION
Added signer docker compose file as extra service, which can be started with an optional flag on all available networks.

Also updated node and API versions to the latest ones:
- `stacks-node`: `3.0.0.0.0`
- `stacks-blockchain-api`: `8.1.0`
- `stacks-signer`: `3.0.0.0.0.0`